### PR TITLE
Weave support

### DIFF
--- a/init-master.bash
+++ b/init-master.bash
@@ -9,7 +9,14 @@ cp --remove-destination /etc/kubernetes/admin.conf $HOME/.kube/config
 chown ${SUDO_UID} $HOME/.kube/config
 
 # Install flannel
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
+#kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
+
+# Install weave
+# From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/
+sysctl net.bridge.bridge-nf-call-iptables=1
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+
+
 
 # Make master node a running worker node too!
 # FIXME: Use taint tolerations instead in the future

--- a/init-master.bash
+++ b/init-master.bash
@@ -1,5 +1,11 @@
 #!/bin/bash
+#
+# Usage: sudo -E ./init-master.bash [pod_network_type]
+#
 set -e
+
+# Read Pod Network type from first arg (default to Flannel)
+POD_NETWORK="${1:-flannel}"
 
 kubeadm init --pod-network-cidr=10.244.0.0/16
 
@@ -8,14 +14,19 @@ mkdir -p $HOME/.kube
 cp --remove-destination /etc/kubernetes/admin.conf $HOME/.kube/config
 chown ${SUDO_UID} $HOME/.kube/config
 
-# Install flannel
-#kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
-
-# Install weave
-# From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/
-sysctl net.bridge.bridge-nf-call-iptables=1
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
-
+if [ "$POD_NETWORK" == "flannel" ]; then
+	# Install flannel
+	#kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
+elif [ "$POD_NETWORK" == "weave" ]; then
+	# Install weave
+	# From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/
+	sysctl net.bridge.bridge-nf-call-iptables=1
+	kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+else
+	echo "Unsupported pod network: $POD_NETWORK"
+	echo "Please choose a supported network type from one of the following: flannel weave"
+	exit 1
+fi
 
 
 # Make master node a running worker node too!

--- a/init-master.bash
+++ b/init-master.bash
@@ -16,7 +16,7 @@ chown ${SUDO_UID} $HOME/.kube/config
 
 if [ "$POD_NETWORK" == "flannel" ]; then
 	# Install flannel
-	#kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
+	kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
 elif [ "$POD_NETWORK" == "weave" ]; then
 	# Install weave
 	# From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/


### PR DESCRIPTION
# Problem
Fixes https://github.com/nds-org/kubeadm-terraform/issues/3 - There is no current configuration option for selecting the desired type of Pod Network.

# Approach
This PR adds an additional value to `variables.tf` for the `pod_network_type`. Currently supported options are `flannel` or `weave`.

NOTE: Flannel will be deployed by default.

# How to test

1. Execute `git clone https://github.com/cheese-hub/kubeadm-bootstrap && cd kubeadm-bootstrap` to clone the repo
2. Execute `sudo ./install-kubeadm.bash` to install kubeadm
3. Execute `sudo -E ./init-master.bash weave` to bootstrap master with weave support
    * If no argument is given, `flannel` will be chosen by default
4. After everything is up, execute `kubectl get pod -n kube-system`
    * You should see that weave is now running instead of flannel