### PR TITLE
Added IPALLOC_RANGE env for weave

### DIFF
--- a/init-master.bash
+++ b/init-master.bash
@@ -7,7 +7,9 @@ set -e
 # Read Pod Network type from first arg (default to Flannel)
 POD_NETWORK="${1:-flannel}"
 
-kubeadm init --pod-network-cidr=10.244.0.0/16
+POD_NETWORK_CIDR=10.244.0.0/16
+
+kubeadm init --pod-network-cidr=${POD_NETWORK_CIDR}
 
 # By now the master node should be ready!
 mkdir -p $HOME/.kube
@@ -21,7 +23,7 @@ elif [ "$POD_NETWORK" == "weave" ]; then
 	# Install weave
 	# From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/
 	sysctl net.bridge.bridge-nf-call-iptables=1
-	kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+	kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')&env.IPALLOC_RANGE=${POD_NETWORK_CIDR}"
 else
 	echo "Unsupported pod network: $POD_NETWORK"
 	echo "Please choose a supported network type from one of the following: flannel weave"


### PR DESCRIPTION
**Problem:**
When using network policies with Weave, there is a known problem with a disconnect between the default Pod network configured on kube-proxy and the default network configured for Weave.  These need to match, otherwise policies don't work as expected. The weave-npc logs will contain entries such as:
```
WARN: 2019/08/16 18:21:31.569889 TCP connection from 10.32.0.1:48026 to 10.36.0.3:8888 blocked by Weave NPC.
```

**Solution:**
* Modify the Weave setup to include the IPALLOC_RANGE environment variable  and set it to the same value used for the pod network during kubeadm init

**To test:**
* Provision Ubuntu 16.04 VM
* Checkout this branch `git clone https://github.com/nds-org/kubeadm-bootstrap -b pod-network-fix`
* Bootstrap instance via `sudo ./install-kubeadm.bash` and `sudo -E ./init-master.bash weave`
* Confirm that the weave Daemonset has the IPALLOC_RANGE env var set to the specified value `kubectl get ds -n kube-system weave-net -o yaml`

I was going to recommend running a basic network policy test via https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/  until we realized that Weave has issues on a single node configuration.

See also:
* https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#configuration-options
* https://github.com/weaveworks/weave/blob/master/site/kubernetes/kube-addon.md#-things-to-watch-out-for

