### PR TITLE
Updates to major dependencies, add cloud-init wait loop, remove kubeadm cleanup on destroy

### DIFF
--- a/init-master.bash
+++ b/init-master.bash
@@ -10,12 +10,10 @@ POD_NETWORK="${1:-weave}"
 POD_NETWORK_CIDR=10.244.0.0/16
 
 # Deploy Kubernetes cluster
-kubeadm init --pod-network-cidr=${POD_NETWORK_CIDR}
-
-# By now the master node should be ready!
-mkdir -p $HOME/.kube
-cp --remove-destination /etc/kubernetes/admin.conf $HOME/.kube/config
-chown ${SUDO_UID} -R $HOME/.kube
+kubeadm init --pod-network-cidr=${POD_NETWORK_CIDR} && \
+  mkdir -p $HOME/.kube && \
+  cp --remove-destination /etc/kubernetes/admin.conf $HOME/.kube/config && \
+  chown ${SUDO_UID} -R $HOME/.kube
 
 if [ "$POD_NETWORK" == "flannel" ]; then
 	# Install flannel
@@ -35,10 +33,8 @@ fi
 # FIXME: Use taint tolerations instead in the future
 kubectl taint nodes --all node-role.kubernetes.io/master-
 
-# Install Helm 3 (no longer needs Tiller)
-curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
-helm repo update
-
-# Deploy NGINX Ingress Controller
-helm install ingress stable/nginx-ingress --namespace=kube-system -f support/values.yaml
+# Install Helm 3 and deploy NGINX Ingress Controller
+curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash && \
+  helm repo add stable https://kubernetes-charts.storage.googleapis.com && \
+  helm repo update && \
+  helm install ingress stable/nginx-ingress --namespace=kube-system -f support/values.yaml

--- a/init-master.bash
+++ b/init-master.bash
@@ -4,8 +4,8 @@
 #
 set -e
 
-# Read Pod Network type from first arg (default to Flannel)
-POD_NETWORK="${1:-flannel}"
+# Read Pod Network type from first arg (default to Weave)
+POD_NETWORK="${1:-weave}"
 
 POD_NETWORK_CIDR=10.244.0.0/16
 
@@ -15,7 +15,7 @@ kubeadm init --pod-network-cidr=${POD_NETWORK_CIDR}
 # By now the master node should be ready!
 mkdir -p $HOME/.kube
 cp --remove-destination /etc/kubernetes/admin.conf $HOME/.kube/config
-chown ${SUDO_UID} $HOME/.kube/config
+chown ${SUDO_UID} -R $HOME/.kube
 
 if [ "$POD_NETWORK" == "flannel" ]; then
 	# Install flannel
@@ -31,33 +31,14 @@ else
 	exit 1
 fi
 
-
 # Make master node a running worker node too!
 # FIXME: Use taint tolerations instead in the future
-#kubectl taint nodes --all node-role.kubernetes.io/master-
-
-# Deprecated: Install Helm 2
-#curl https://storage.googleapis.com/kubernetes-helm/helm-v2.8.0-linux-amd64.tar.gz | tar xvz
-#mv linux-amd64/helm /usr/local/bin
-#rm -rf linux-amd64
-
-# Bootstrap and run tiller deployment
-#kubectl --namespace kube-system create sa tiller
-#kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-#helm init --service-account tiller
-#kubectl --namespace=kube-system patch deployment tiller-deploy --type=json --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/command", "value": ["/tiller", "--listen=localhost:44134"]}]'
-
-# Wait for tiller to be ready!
-#kubectl rollout status --namespace=kube-system deployment/tiller-deploy --watch
+kubectl taint nodes --all node-role.kubernetes.io/master-
 
 # Install Helm 3 (no longer needs Tiller)
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 helm repo add stable https://kubernetes-charts.storage.googleapis.com
 helm repo update
-
-# Install nginx and other support stuff!
-#cd support && helm dep up && cd ..
-#helm install --name=support --namespace=support support/
 
 # Install NFS provisioner (handled by other script)
 # helm install nfs stable/nfs-server-provisioner --namespace=kube-system --set storageClass.defaultClass=true
@@ -65,7 +46,4 @@ helm repo update
 # STABLE (allegedly), but needs testing
 helm repo add nginx-stable https://helm.nginx.com/stable
 helm repo update
-helm install ingress nginx-stable/nginx-ingress --namespace=kube-system --set service.type=ClusterIP --set controller.hostNetwork=true --set controller.nodeSelector."external-ip"=true
 
-# DEPRECATED, but working
-#helm install ingress stable/nginx-ingress --namespace=kube-system --set controller.hostNetwork=true --set controller.nodeSelector."external-ip"=true

--- a/init-master.bash
+++ b/init-master.bash
@@ -40,10 +40,7 @@ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bas
 helm repo add stable https://kubernetes-charts.storage.googleapis.com
 helm repo update
 
-# Install NFS provisioner (handled by other script)
-# helm install nfs stable/nfs-server-provisioner --namespace=kube-system --set storageClass.defaultClass=true
-
-# STABLE (allegedly), but needs testing
+# Deploy NGINX Ingress Controller
 helm repo add nginx-stable https://helm.nginx.com/stable
 helm repo update
-
+helm install ingress nginx-stable/nginx-ingress --namespace=kube-system -f support/values.yaml

--- a/init-master.bash
+++ b/init-master.bash
@@ -41,6 +41,4 @@ helm repo add stable https://kubernetes-charts.storage.googleapis.com
 helm repo update
 
 # Deploy NGINX Ingress Controller
-helm repo add nginx-stable https://helm.nginx.com/stable
-helm repo update
-helm install ingress nginx-stable/nginx-ingress --namespace=kube-system -f support/values.yaml
+helm install ingress stable/nginx-ingress --namespace=kube-system -f support/values.yaml

--- a/init-services.bash
+++ b/init-services.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+# 
+# Usage: sudo -E./init-services.bash [pod_network_type]
+#
+
+helm install ingress nginx-stable/nginx-ingress --namespace=kube-system -f support/values.yaml
+
+# DEPRECATED, but working
+#helm install ingress stable/nginx-ingress --namespace=kube-system -f support/values.yaml

--- a/init-services.bash
+++ b/init-services.bash
@@ -1,9 +1,0 @@
-#!/bin/bash
-# 
-# Usage: sudo -E./init-services.bash [pod_network_type]
-#
-
-helm install ingress nginx-stable/nginx-ingress --namespace=kube-system -f support/values.yaml
-
-# DEPRECATED, but working
-#helm install ingress stable/nginx-ingress --namespace=kube-system -f support/values.yaml

--- a/install-kubeadm.bash
+++ b/install-kubeadm.bash
@@ -4,7 +4,7 @@
 apt-get update && apt-get upgrade -qq
 
 # Install Docker + Kubernetes dependencies, add repos
-apt-get install -qq apt-transport-https      ca-certificates     curl     gnupg-agent     software-properties-common
+apt-get install -qq --no-install-recommends apt-transport-https      ca-certificates     curl     gnupg-agent     software-properties-common
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
@@ -15,6 +15,7 @@ EOF
 # Install Docker CE
 apt-get update
 apt-get install -qq docker-ce docker-ce-cli containerd.io
+apt-mark hold docker-ce docker-ce-cli containerd.io
 
 # Configure Docker
 systemctl stop docker
@@ -23,10 +24,9 @@ echo '{"storage-driver": "overlay2"}' > /etc/docker/daemon.json
 rm -rf /var/lib/docker/*
 systemctl start docker
 
-# Install kubernetes components
-apt-get update && \
-  apt-get install -y kubelet kubeadm kubectl && \
-  apt-mark hold kubelet kubeadm kubectl
+# Install Kubernetes components
+apt-get install -qq kubelet kubeadm kubectl
+apt-mark hold kubelet kubeadm kubectl
 
 # Bootstrap system for Kubernetes
 cat <<EOF | >/etc/sysctl.d/k8s.conf
@@ -34,7 +34,7 @@ net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables = 1
 EOF
 
-# Start up Kubernetes
+# Start up Kubelets
 sysctl --system
 systemctl daemon-reload
 systemctl restart kubelet

--- a/install-kubeadm.bash
+++ b/install-kubeadm.bash
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 # Install Docker + Kubernetes dependencies, add repos
-apt-get update  -qq
-apt-get install -qq --no-install-recommends apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+apt-get update  -qq && \
+  apt-get update  -qq && \
+  apt-get install -qq --no-install-recommends apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
@@ -11,9 +13,10 @@ deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
 EOF
 
 # Install Docker CE
-apt-get update -qq
-apt-get install -qq docker-ce docker-ce-cli containerd.io
-apt-mark hold docker-ce docker-ce-cli containerd.io
+apt-get update -qq && \
+  apt-get update -qq && \
+  apt-get install -qq docker-ce docker-ce-cli containerd.io && \
+  apt-mark hold docker-ce docker-ce-cli containerd.io
 
 # Configure Docker
 systemctl stop docker
@@ -23,8 +26,8 @@ rm -rf /var/lib/docker/*
 systemctl start docker
 
 # Install Kubernetes components
-apt-get install -qq kubelet kubeadm kubectl
-apt-mark hold kubelet kubeadm kubectl
+apt-get install -qq kubelet kubeadm kubectl && \
+  apt-mark hold kubelet kubeadm kubectl
 
 # Bootstrap system for Kubernetes
 cat <<EOF | >/etc/sysctl.d/k8s.conf

--- a/install-kubeadm.bash
+++ b/install-kubeadm.bash
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# Upgrade OS dependencies
-apt-get update && apt-get upgrade -qq
-
 # Install Docker + Kubernetes dependencies, add repos
-apt-get install -qq --no-install-recommends apt-transport-https      ca-certificates     curl     gnupg-agent     software-properties-common
+apt-get update  -qq
+apt-get install -qq --no-install-recommends apt-transport-https ca-certificates curl gnupg-agent software-properties-common
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
@@ -13,7 +11,7 @@ deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
 EOF
 
 # Install Docker CE
-apt-get update
+apt-get update -qq
 apt-get install -qq docker-ce docker-ce-cli containerd.io
 apt-mark hold docker-ce docker-ce-cli containerd.io
 

--- a/install-kubeadm.bash
+++ b/install-kubeadm.bash
@@ -1,6 +1,10 @@
 #!/bin/bash
-apt-get update
-apt-get install -y apt-transport-https
+
+# Upgrade OS dependencies
+apt-get update && apt-get upgrade -qq
+
+# Install Docker + Kubernetes dependencies, add repos
+apt-get install -qq apt-transport-https      ca-certificates     curl     gnupg-agent     software-properties-common
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
@@ -8,18 +12,29 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
 EOF
 
+# Install Docker CE
 apt-get update
+apt-get install -qq docker-ce docker-ce-cli containerd.io
 
-apt-get install -y docker-ce=17.03.2~ce-0~ubuntu-xenial
-
+# Configure Docker
 systemctl stop docker
 modprobe overlay
 echo '{"storage-driver": "overlay2"}' > /etc/docker/daemon.json
 rm -rf /var/lib/docker/*
 systemctl start docker
 
-# Install kubernetes components!
-apt-get install -y \
-        kubelet=1.9.2-00 \
-        kubeadm=1.9.2-00 \
-        kubernetes-cni=0.6.0-00
+# Install kubernetes components
+apt-get update && \
+  apt-get install -y kubelet kubeadm kubectl && \
+  apt-mark hold kubelet kubeadm kubectl
+
+# Bootstrap system for Kubernetes
+cat <<EOF | >/etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+EOF
+
+# Start up Kubernetes
+sysctl --system
+systemctl daemon-reload
+systemctl restart kubelet

--- a/install-kubeadm.bash
+++ b/install-kubeadm.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Wait for instance to finish booting
+until [[ -f /var/lib/cloud/instance/boot-finished ]]; do
+  sleep 1
+done
+
 # Install Docker + Kubernetes dependencies, add repos
 apt-get update  -qq && \
   apt-get update  -qq && \

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,8 +1,7 @@
-nginx-ingress:
-  rbac:
-   create: true
-  controller:
-    service:
-      type: ClusterIP
-    kind: DaemonSet
-    hostNetwork: true
+rbac:
+ create: true
+controller:
+  service:
+    type: ClusterIP
+  kind: daemonset 
+  hostNetwork: true

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,7 +1,5 @@
-rbac:
- create: true
 controller:
   service:
     type: ClusterIP
-  kind: daemonset 
+  kind: DaemonSet 
   hostNetwork: true


### PR DESCRIPTION
## Problem
This repo deploys an outdated (unsupported) version of Kubernetes

## Approach
* Upgrade to Kubernetes / kubeadm / kubelet / kubectl 1.19
* Upgrade to Helm 3.3
* Change default network to weave
* Removed Tiller deployment (Tiller is no longer necessary in Helm3+)
* Switch to using official NGINX Helm chart, reuse same `values.yaml`

## How to Test
1. Deploy a fresh Ubuntu 16.04 LTS machine
2. Upgrade OS dependencies: `apt-get -qq update && apt-get -qq upgrade`
3. Clone this repo locally: `git clone https://github.com/nds-org/kubeadm-bootstrap -b bootstrapping-fixup && kubeadm-bootstrap/`
4. Install kubeadm and friends: `sudo ./install-kubeadm.bash`
5. Run kubeadm to start up Kubernetes: `sudo -E ./init-master.bash`
6. Wait for the process to finish
7. Run `kubectl get pods -A` and ensure that the cluster is Running